### PR TITLE
Backport GitHub transport fix from the main kraft's repo

### DIFF
--- a/kraft/cmd/list/add.py
+++ b/kraft/cmd/list/add.py
@@ -32,31 +32,40 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
+import os
 import sys
 from urllib.parse import urlparse
 
 import click
 
+from kraft.cmd.list.update import kraft_update
 from kraft.const import KRAFTRC_LIST_ORIGINS
 from kraft.logger import logger
 
 
 @click.pass_context
-def kraft_list_add(ctx, origin=None):
+def kraft_list_add(ctx, origin=None, update=False):
     """
     """
     if isinstance(origin, list):
         for o in origin:
-            kraft_list_add(o)
+            kraft_list_add(o, update=update)
         return
 
-    new_uri = urlparse(origin)
     existing_origins = ctx.obj.settings.get(KRAFTRC_LIST_ORIGINS)
     if existing_origins is None:
         existing_origins = list()
+
+    new_uri = urlparse(origin)
+
+    if os.path.exists(origin):
+        origin = os.path.abspath(origin)
+
     for o in existing_origins:
         cur_uri = urlparse(o)
-        if new_uri.netloc == cur_uri.netloc and new_uri.path == cur_uri.path:
+        if (o == origin
+                or (new_uri.netloc == cur_uri.netloc
+                    and new_uri.path == cur_uri.path)):
             logger.warning("Origin already saved: %s" % o)
             return
 
@@ -64,17 +73,26 @@ def kraft_list_add(ctx, origin=None):
     ctx.obj.settings.set(KRAFTRC_LIST_ORIGINS, existing_origins)
     logger.info("Saved: %s" % origin)
 
+    if update:
+        with ctx:
+            kraft_update(origin)
+
 
 @click.command('add', short_help='Add a remote manifest or repository.')
+@click.option(
+    '--update/--no-update', 'update',
+    help='Update the list of known remote components.',
+    default=False
+)
 @click.argument('origin', nargs=-1)
 @click.pass_context
-def cmd_list_add(ctx, origin=None):
+def cmd_list_add(ctx, update=False, origin=None):
     """
     Add a remote repository to search for components.
     """
 
     try:
-        kraft_list_add(list(origin))
+        kraft_list_add(list(origin), update=update)
 
     except Exception as e:
         logger.critical(str(e))

--- a/kraft/cmd/list/list.py
+++ b/kraft/cmd/list/list.py
@@ -216,8 +216,6 @@ def cmd_list(ctx, show_installed=False, show_core=False, show_plats=False,
                     latest_release = row.dists[UNIKRAFT_RELEASE_STABLE].latest
                 elif UNIKRAFT_RELEASE_STAGING in row.dists.keys():
                     latest_release = row.dists[UNIKRAFT_RELEASE_STAGING].latest
-                elif len(row.dists.keys()) == 1:
-                    latest_release = row.dists[list(row.dists.keys())[0]].latest
 
                 if return_json:
                     if member.plural not in data_json:

--- a/kraft/cmd/list/provider/github.py
+++ b/kraft/cmd/list/provider/github.py
@@ -106,7 +106,7 @@ class GitHubListProvider(GitListProvider):
 
             # Does the origin contain a wildcard in the repo name?
             if "*" in github_repo:
-                logger.debug("Populating via wildcard: %s" % origin)
+                logger.info("Populating via wildcard: %s" % origin)
 
                 org = github_api.get_organization(github_org)
                 repos = org.get_repos()
@@ -132,7 +132,7 @@ class GitHubListProvider(GitListProvider):
                             repo.name
                         ))
             else:
-                logger.debug("Using Github repository: %s" % origin)
+                logger.info("Using direct repository: %s" % origin)
 
                 if return_threads:
                     thread = ErrorPropagatingThread(
@@ -213,13 +213,17 @@ def get_component_from_github(ctx, origin=None, org=None, repo=None):
 
     _type, _name, _, _ = break_component_naming_format(repo.name)
 
+    remote_git = repo.html_url
+    if "git@" in origin or "ssh://" in origin:
+        remote_git = repo.ssh_url
+
     item = ManifestItem(
         provider=ListProviderType.GITHUB,
         name=_name,
         description=repo.description,
         type=_type.shortname,
         dist=UNIKRAFT_RELEASE_STABLE,
-        git=repo.git_url,
+        git=remote_git,
         manifest=origin,
     )
 

--- a/kraft/cmd/list/remove.py
+++ b/kraft/cmd/list/remove.py
@@ -32,6 +32,7 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
+import os
 import sys
 from urllib.parse import urlparse
 
@@ -50,11 +51,20 @@ def kraft_list_remove(ctx, origin=None):
             kraft_list_remove(o)
         return
 
-    new_uri = urlparse(origin)
     existing_origins = ctx.obj.settings.get(KRAFTRC_LIST_ORIGINS)
+    if existing_origins is None:
+        existing_origins = list()
+
+    new_uri = urlparse(origin)
+
+    if os.path.exists(origin):
+        origin = os.path.abspath(origin)
+
     for i, o in enumerate(existing_origins):
         cur_uri = urlparse(o)
-        if new_uri.netloc == cur_uri.netloc and new_uri.path == cur_uri.path:
+        if (o == origin
+                or (new_uri.netloc == cur_uri.netloc
+                    and new_uri.path == cur_uri.path)):
             logger.info("Removed: %s" % origin)
             del existing_origins[i]
             break


### PR DESCRIPTION
This should fix the following pull issue we encounter when building flexos container images:
```
[ERROR   ] Could not fetch git://github.com/project-flexos/unikraft.git: Cmd('git') failed due to: exit code(128)
  cmdline: git fetch -v origin
  stderr: 'fatal: remote error:'
```

The main version of kraft (on Unikraft's repo) has significantly evolved compared to the FlexOS one. I tried to backport as few code as needed from kraft's unikraft repo, it basically corresponds to the changes brought in `kraft/cmd/list`.

I tested it locally and I'm able to reproduce `fig-11_flexos-alloc-latency`. If these changes are accepted, one would need to regenerate `ghcr.io/project-flexos/flexos-base:latest` for the scripts on the AE repo to take the fix into account.